### PR TITLE
docs(readme): update API reference with actual backend endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,12 @@ python -m app.engines.static_analysis.cli path/to/sample.exe
 
 | Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/api/v1/health` | Healthcheck and service status |
-| `POST` | `/api/v1/analyze` | Submit PE binary for static analysis |
-| `GET` | `/api/v1/analyses` | List recent sample analysis history |
-| `GET` | `/api/v1/analyses/{id}` | Retrieve comprehensive analysis report & SHAP attributions |
-| `DELETE` | `/api/v1/analyses/{id}` | Remove sample record and analysis data |
+| `GET` | `/api/v1/health` | Healthcheck and service readiness status |
+| `POST` | `/api/v1/analyze` | Submit PE binary for static malware analysis |
+| `GET` | `/api/v1/history` | Retrieve recent sample analysis history |
+| `GET` | `/api/v1/report/search` | Search past analyses by filename or hash |
+| `GET` | `/api/v1/report/{sha256}` | Retrieve comprehensive report by sample SHA256 hash |
+| `GET` | `/api/v1/report/id/{analysis_id}` | Retrieve analysis report by record ID |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the API Reference section in `README.md` to accurately reflect the backend endpoints currently implemented in `backend/app/api/endpoints.py`.

## Changes

* Updated the `/api/v1/health` endpoint description.
* Updated the `/api/v1/analyze` endpoint description.
* Replaced the outdated `/api/v1/analyses` endpoint with `/api/v1/history`.
* Added `/api/v1/report/search` for searching analyses by filename or hash.
* Added `/api/v1/report/{sha256}` for retrieving reports by sample SHA256 hash.
* Added `/api/v1/report/id/{analysis_id}` for retrieving reports by analysis record ID.
* Removed outdated endpoint references from the API Reference table.

## Related Issue

Closes #11

## Verification

* Verified the documented routes against `backend/app/api/endpoints.py`.
* Confirmed that only the relevant API Reference documentation was modified.
